### PR TITLE
Add note about necessary ODBC headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Easiest install is to use pip:
 
     pip install dbt-sqlserver
 
+On Ubuntu make sure you have the ODBC header files before installing
+    
+    sudo apt install unixodbc-dev
  
 ## Configure your profile
 Configure your dbt profile for using SQL Server authentication or Integrated Security:


### PR DESCRIPTION
I installed this in an Ubuntu 18.04 based Docker and installation failed because of the missing ODBC headers required by pyodbc.

See: https://github.com/mkleehammer/pyodbc/issues/441